### PR TITLE
feat: adds an initiated callback after websocket opens

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -414,7 +414,7 @@ export function useAntMedia(params: Params) {
         iceCandidateList[streamId] = [];
         if (isTypeOffer) {
           const configur = await remotePeerConnection[streamId].createAnswer(
-            
+
           );
           await gotDescription(configur, streamId);
         }
@@ -500,7 +500,7 @@ export function useAntMedia(params: Params) {
   useEffect(() => {
     ws.onopen = () => {
       if (debug) console.log('web socket opened !');
-
+      callback.call(adaptorRef.current, 'initiated');
       // connection opened
 
       if (!onlyDataChannel) {


### PR DESCRIPTION
Experienced a race condition when trying to auto-start a stream (without using a play button)

I found that I needed to wait for the websocket to connect before playing 
Adding an initiated callback to when the WebSocket opens allows me to properly auto-play a stream

example use-case:

```
    callback(command: any) {
      if (command === 'initiated') {
        adaptor.play('stream1');
      }
    },
```